### PR TITLE
Fix sign up promise error

### DIFF
--- a/front-end/src/components/Auth/signup.js
+++ b/front-end/src/components/Auth/signup.js
@@ -26,7 +26,7 @@ export default class SignUp extends Component {
         console.log(error);
         this.setState({ signUpError: error.message });
       })
-      .finally(() => {
+      .then(() => {
         this.setState({ isLoading: false });
       });
   };


### PR DESCRIPTION
Firebase auth promise doesn't have a `finally()`, so use `then()` instead.